### PR TITLE
Provide more idiot friendly error messages

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -856,7 +856,7 @@ async def cmd_autodaily_post(ctx: discord.ext.commands.Context):
 
 @bot.command(brief='Get crew levelling costs', name='level', aliases=['lvl'])
 @discord.ext.commands.cooldown(rate=RATE, per=COOLDOWN, type=discord.ext.commands.BucketType.user)
-async def cmd_level(ctx: discord.ext.commands.Context, from_level: int, to_level: int = None):
+async def cmd_level(ctx: discord.ext.commands.Context, from_level: str, to_level: str = None):
     """
     Shows the cost for a crew to reach a certain level.
 
@@ -872,13 +872,19 @@ async def cmd_level(ctx: discord.ext.commands.Context, from_level: int, to_level
       /level 35 - Prints exp and gas requirements from level 1 to 35
       /level 25 35 - Prints exp and gas requirements from level 25 to 35"""
     async with ctx.typing():
-        output, _ = crew.get_level_costs(from_level, to_level)
+        try:
+            from_level = int(from_level)
+            to_level = None if to_level is None else int(to_level)
+        except ValueError:
+            output = f"Arguments to `{util.get_exact_cmd(ctx)}` need to be numbers."
+        else:
+            output, _ = crew.get_level_costs(from_level, to_level)
     await util.post_output(ctx, output)
 
 
 @bot.group(brief='Prints top fleets or captains', name='top', invoke_without_command=True)
 @discord.ext.commands.cooldown(rate=RATE, per=COOLDOWN, type=discord.ext.commands.BucketType.user)
-async def cmd_top(ctx: discord.ext.commands.Context, count: int = 100):
+async def cmd_top(ctx: discord.ext.commands.Context, count: str = 100):
     """
     Prints either top fleets or captains. Prints top 100 fleets by default.
 
@@ -897,7 +903,7 @@ async def cmd_top(ctx: discord.ext.commands.Context, count: int = 100):
 
 
 @cmd_top.command(brief='Prints top fleets', name='fleets', aliases=['alliances'])
-async def cmd_top_fleets(ctx: discord.ext.commands.Context, count: int = 100):
+async def cmd_top_fleets(ctx: discord.ext.commands.Context, count: str = 100):
     """
     Prints top fleets. Prints top 100 fleets by default.
 
@@ -911,12 +917,17 @@ async def cmd_top_fleets(ctx: discord.ext.commands.Context, count: int = 100):
       /top fleets - prints top 100 fleets.
       /top fleets 30 - prints top 30 fleets."""
     async with ctx.typing():
-        output, _ = pss_top.get_top_fleets(count)
+        try:
+            count = int(count)
+        except ValueError:
+            output = f"The argument to `{util.get_exact_cmd(ctx)}` needs to be a number.\nMaybe you meant to use `{ctx.prefix}stars fleet`?"
+        else:
+            output, _ = pss_top.get_top_fleets(count)
     await util.post_output(ctx, output)
 
 
 @cmd_top.command(brief='Prints top captains', name='players', aliases=['captains', 'users'])
-async def cmd_top_captains(ctx: discord.ext.commands.Context, count: int = 100):
+async def cmd_top_captains(ctx: discord.ext.commands.Context, count: str = 100):
     """
     Prints top captains. Prints top 100 captains by default.
 
@@ -930,6 +941,11 @@ async def cmd_top_captains(ctx: discord.ext.commands.Context, count: int = 100):
       /top captains - prints top 100 captains.
       /top captains 30 - prints top 30 captains."""
     async with ctx.typing():
+      try:
+        count = int(count)
+      except ValueError:
+          output = f"The argument to `{util.get_exact_cmd(ctx)}` needs to be a number.\nMaybe you meant to use `{ctx.prefix}stars fleet`?"
+      else:
         output, _ = pss_top.get_top_captains(count)
     await util.post_output(ctx, output)
 
@@ -969,7 +985,7 @@ async def cmd_training(ctx: discord.ext.commands.Context, *, name: str = None):
       /training [name]
 
     Parameters:
-      name: A room's name or part of it. Mandatory.
+      name: A training's name or part of it. Mandatory.
 
     Examples:
       /training bench - Searches for trainings having 'bench' in their names and prints their details.

--- a/src/utility.py
+++ b/src/utility.py
@@ -554,7 +554,7 @@ async def try_remove_reaction(reaction: discord.Reaction, user: discord.User) ->
         return False
 
 
-def get_exact_args(ctx: discord.ext.commands.Context) -> str:
+def get_exact_cmd(ctd: discord.ext.commands.Context) -> str:
     try:
         if ctx.command.full_parent_name:
             parent_command = f'{ctx.command.full_parent_name} '
@@ -567,6 +567,19 @@ def get_exact_args(ctx: discord.ext.commands.Context) -> str:
                 command = f'{full_parent_command}{alias} '
                 if ctx.message.content.startswith(command):
                     break
+        return command[:-1]
+    except:
+        return ''
+
+
+def get_exact_args(ctx: discord.ext.commands.Context) -> str:
+    command = get_exact_cmd(ctx)
+    if command == '':
+        return ''
+    else:
+        command = command + ' '
+
+    try:
         args = str(ctx.message.content[len(command):])
         return args
     except:


### PR DESCRIPTION
Changed some `int` parameters to `str` so a better message than `Converting to "int" failed for parameter "count"` can be provided when someone tries to pass words to a command expecting numbers.

Note that I don't have my own copy of Dolores up and running yet, so these changes aren't exactly tested yet. And they're the first python code I've written.

Feel free to tell me to bugger off now 😉.