### PR TITLE
Hotfix/1.4.2.3

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -102,7 +102,7 @@ USE_EMBEDS: bool = True
 USE_ACCESS_TOKEN: int = int(os.environ.get('USE_ACCESS_TOKEN', 0))
 
 
-VERSION: str = '1.4.2.2'
+VERSION: str = '1.4.2.3'
 
 
 WIKI_COMMAND_GUILDS: List[str] = json.loads(os.environ.get('WIKI_COMMAND_GUILDS', '[]'))


### PR DESCRIPTION
- Fixes CSV output of fleet data:
  - Changed delimiter from tab (`\t`) to semicolon (`;`)
  - Any fleet or player name enclosed in double quotes is escaped so that upon importing the data in excel, it'll still be enclosed in double quotes
  - Any fleet or player name containing the delimiter is now escaped in double quotes
  - Any fleet or player name containing a number is now escaped in double quotes