### PR TITLE
Fix Issue #364

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ items-*.txt
 *.db
 *.csv
 sprite_cache/
+files_cache/
 bin/
 pyvenv.cfg
 *.lua

--- a/src/pss_entity.py
+++ b/src/pss_entity.py
@@ -764,7 +764,7 @@ class EntityRetriever:
         self.__sorted_key_function: Callable[[dict, dict], str] = sorted_key_function
         self.__fix_data_delegate: Callable[[str], str] = fix_data_delegate
 
-        self.__cache = PssCache(self.__base_path, self.__cache_name, key_name=self.__key_name, update_interval=cache_update_interval)
+        self._cache = PssCache(self.__base_path, self.__cache_name, key_name=self.__key_name, update_interval=cache_update_interval)
 
     @property
     def base_path(self) -> str:
@@ -779,7 +779,7 @@ class EntityRetriever:
         return self.__key_name
 
     async def get_data_dict3(self) -> Dict[str, Dict[str, object]]:
-        return await self.__cache.get_data_dict3()
+        return await self._cache.get_data_dict3()
 
     async def get_entity_info_by_name(self, entity_name: str, entities_data: EntitiesData = None) -> Dict[str, object]:
         entities_data = entities_data or await self.get_data_dict3()
@@ -812,11 +812,11 @@ class EntityRetriever:
         return results
 
     async def get_raw_data(self) -> str:
-        return await self.__cache.get_raw_data()
+        return await self._cache.get_raw_data()
 
     async def get_raw_entity_info_by_id_as_xml(self, entity_id: str) -> str:
         result = None
-        raw_data = await self.__cache.get_raw_data()
+        raw_data = await self._cache.get_raw_data()
         for element in ElementTree.fromstring(raw_data).iter():
             element_id = element.attrib.get(self.__key_name)
             if element_id == entity_id:
@@ -834,7 +834,7 @@ class EntityRetriever:
         return result
 
     async def update_cache(self) -> None:
-        await self.__cache.update_data()
+        await self._cache.update_data()
 
 
 # ---------- Helper ----------

--- a/src/pss_sprites.py
+++ b/src/pss_sprites.py
@@ -1,10 +1,11 @@
-import aiohttp
 import colorsys
 import os
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
-from PIL import Image, ImageEnhance, ImageFont
+import aiohttp
 import numpy as np
+from PIL import Image, ImageEnhance, ImageFont
 
 from . import pss_core as core
 from . import pss_entity as entity
@@ -29,14 +30,75 @@ POWER_BAR_Y_START: int = 3
 PWD: str
 
 
-SPRITES_BASE_PATH: str = 'FileService/DownloadSprite?spriteId='
+LIST_SPRITES_BASE_PATH: str = "FileService/ListSprites2"
+LIST_SPRITES_KEY_NAME: str = "SpriteId"
+LIST_SPRITES_DESCRIPTION_PROPERTY_NAME: str = "SpriteKey"
+
+FILES_CACHE_PATH: str
+
+SPRITES_BASE_PATH: str = "FileService/DownloadSprite?spriteId="
 SPRITES_CACHE_PATH: str
 
 
 TILE_SIZE = 25
 
 
+# ---------- Classes ----------
 
+
+@dataclass
+class Sprite:
+    sprite_id: int
+    image_file_id: int
+    x: int
+    y: int
+    height: int
+    width: int
+    sprite_key: str
+
+    @property
+    def file_download_url(self) -> str:
+        return f"https://pixelstarships.s3.amazonaws.com/{self.image_file_id}.png"
+
+    @property
+    def sprite_download_url(self) -> str:
+        return f"{SPRITES_BASE_PATH}{self.sprite_id}"
+
+
+class SpriteListRetriever(entity.EntityRetriever):
+    def __init__(self):
+        super().__init__(LIST_SPRITES_BASE_PATH, LIST_SPRITES_KEY_NAME, LIST_SPRITES_DESCRIPTION_PROPERTY_NAME, cache_name="ListSprites")
+        self.__sprite_list: dict[int, Sprite] = {}
+
+    @property
+    def sprite_list(self) -> dict[int, Sprite]:
+        return self.__sprite_list
+
+    async def build_sprite_list_cache(self) -> None:
+        for sprite_id, sprite_info in (await self._cache.get_data_dict3()).items():
+            image_file_id = str(sprite_info.get("ImageFileId"))
+            x = str(sprite_info.get("X"))
+            y = str(sprite_info.get("Y"))
+            height = str(sprite_info.get("Height"))
+            width = str(sprite_info.get("Width"))
+            sprite_key = str(sprite_info.get("SpriteKey"))
+
+            if sprite_id and image_file_id and x and y and height and width:
+                self.__sprite_list[int(sprite_id)] = Sprite(
+                    sprite_id=int(sprite_id),
+                    image_file_id=int(image_file_id),
+                    x=int(x),
+                    y=int(y),
+                    height=int(height),
+                    width=int(width),
+                    sprite_key=sprite_key,
+                )
+
+    async def get_data_dict3(self) -> dict[str, dict[str, object]]:
+        result = await self._cache.get_data_dict3()
+        await self.build_sprite_list_cache()
+
+        return result
 
 
 # ---------- Sprites ----------
@@ -47,9 +109,9 @@ def colorize(image: Image.Image, hue: float) -> Image.Image:
     Colorize PIL image `original` with the given
     `hue` (hue within 0-360); returns another PIL image.
     """
-    img = image.convert('RGBA')
-    arr = np.array(np.asarray(img).astype('float'))
-    new_img = Image.fromarray(shift_hue(arr, hue).astype('uint8'), 'RGBA')
+    img = image.convert("RGBA")
+    arr = np.array(np.asarray(img).astype("float"))
+    new_img = Image.fromarray(shift_hue(arr, hue).astype("uint8"), "RGBA")
 
     return new_img
 
@@ -59,20 +121,30 @@ def create_empty_room_sprite(room_width: int, room_height: int) -> Image.Image:
 
 
 def create_empty_sprite(width: int, height: int) -> Image.Image:
-    return Image.new('RGBA', (width, height), (255, 0, 0, 0))
+    return Image.new("RGBA", (width, height), (255, 0, 0, 0))
 
 
 async def download_sprite(sprite_id: str) -> str:
     """
-    Returns a file path and whether the file already existed before.
+    Returns the target file path.
     """
-    target_path = os.path.join(SPRITES_CACHE_PATH, f'{sprite_id}.png')
+    target_path = os.path.join(SPRITES_CACHE_PATH, f"{sprite_id}.png")
     if not os.path.isfile(target_path):
-        download_url = await get_download_sprite_link(sprite_id)
-        async with aiohttp.ClientSession() as session:
-            async with session.get(download_url) as response:
-                with open(target_path, 'wb') as f:
-                    f.write(await response.read())
+        sprite: Sprite | None = sprite_list_retriever.sprite_list.get(int(sprite_id))
+        if not sprite:
+            raise ValueError(f"Sprite with id {sprite_id} not found in sprite list cache.")
+
+        file_target_path = os.path.join(FILES_CACHE_PATH, f"{sprite.image_file_id}.png")
+        if not os.path.isfile(file_target_path):
+            await download_file(sprite, file_target_path)
+
+            if not os.path.isfile(file_target_path):
+                raise ValueError(f"Failed to download sprite file with file id {sprite.image_file_id} for sprite id {sprite_id}.")
+
+        image_file = Image.open(file_target_path).convert("RGBA")
+        sprite_image = image_file.crop((sprite.x, sprite.y, sprite.x + sprite.width, sprite.y + sprite.height))
+        sprite_image.save(target_path)
+
     return target_path
 
 
@@ -90,7 +162,7 @@ def enhance_sprite(sprite: Image.Image, brightness: float = None, hue: float = N
 
 def exists_in_cache(sprite_id: str, prefix: str = None, suffix: str = None) -> str:
     file_name = f'{prefix if prefix else ""}{sprite_id}{suffix if suffix else ""}'
-    target_path = os.path.join(SPRITES_CACHE_PATH, f'{file_name}.png')
+    target_path = os.path.join(SPRITES_CACHE_PATH, f"{file_name}.png")
     if os.path.isfile(target_path):
         return target_path
     else:
@@ -100,14 +172,14 @@ def exists_in_cache(sprite_id: str, prefix: str = None, suffix: str = None) -> s
 async def get_download_sprite_link(sprite_id: str) -> Optional[str]:
     if entity.entity_property_has_value(sprite_id):
         base_url = await core.get_base_url()
-        result = f'{base_url}FileService/DownloadSprite?spriteId={sprite_id}'
+        result = f"{base_url}FileService/DownloadSprite?spriteId={sprite_id}"
         return result
     else:
         return None
 
 
 async def get_download_sprite_link_by_property(entity_info: EntityInfo, *entities_data: EntitiesData, **kwargs) -> str:
-    entity_property = kwargs.get('entity_property')
+    entity_property = kwargs.get("entity_property")
     return await get_download_sprite_link(entity_property)
 
 
@@ -118,29 +190,29 @@ def get_file_path(sprite_id: str, prefix: str = None, suffix: str = None) -> str
     file_name_parts.append(sprite_id)
     if suffix:
         file_name_parts.append(suffix)
-    return os.path.join(SPRITES_CACHE_PATH, '_'.join(file_name_parts) + '.png')
+    return os.path.join(SPRITES_CACHE_PATH, "_".join(file_name_parts) + ".png")
 
 
 def get_sprite_download_url(sprite_id: int) -> str:
-    return f'{SPRITES_BASE_PATH}{sprite_id}'
+    return f"{SPRITES_BASE_PATH}{sprite_id}"
 
 
 async def load_sprite(sprite_id: str) -> Image.Image:
     sprite_path = await download_sprite(sprite_id)
-    result = Image.open(sprite_path).convert('RGBA')
+    result = Image.open(sprite_path).convert("RGBA")
     return result
 
 
 async def load_sprite_from_disk(sprite_id: str, prefix: str = None, suffix: str = None) -> Optional[Image.Image]:
     file_path = get_file_path(sprite_id, prefix=prefix, suffix=suffix)
     try:
-        return Image.open(file_path).convert('RGBA')
+        return Image.open(file_path).convert("RGBA")
     except IOError:
         return None
 
 
 def save_sprite(image: Image.Image, file_name_without_extension: str) -> str:
-    target_file_path = os.path.join(SPRITES_CACHE_PATH, f'{file_name_without_extension}.png')
+    target_file_path = os.path.join(SPRITES_CACHE_PATH, f"{file_name_without_extension}.png")
     image.save(target_file_path)
     return target_file_path
 
@@ -154,19 +226,41 @@ def shift_hue(arr: Iterable, hue_out: float) -> Iterable:
     return arr
 
 
+async def download_file(sprite: Sprite, file_target_path: str) -> None:
+    file_download_url = sprite.file_download_url
 
-
+    async with aiohttp.ClientSession() as session:
+        async with session.get(file_download_url) as response:
+            sprite_file = await response.read()
+            with open(file_target_path, "wb") as f:
+                f.write(sprite_file)
 
 
 # ---------- Initialization ----------
 
+
+sprite_list_retriever = SpriteListRetriever()
+
+
 async def init():
     global PWD
     PWD = os.getcwd()
+
     sprites_cache_path = os.path.join(PWD, settings.SPRITE_CACHE_SUB_PATH)
     if not os.path.isdir(sprites_cache_path):
         os.makedirs(settings.SPRITE_CACHE_SUB_PATH)
+
+    files_cache_path = os.path.join(PWD, settings.FILES_CACHE_SUB_PATH)
+    if not os.path.isdir(files_cache_path):
+        os.makedirs(settings.FILES_CACHE_SUB_PATH)
+
+    await sprite_list_retriever.get_data_dict3()
+
     global SPRITES_CACHE_PATH
     SPRITES_CACHE_PATH = sprites_cache_path
+
+    global FILES_CACHE_PATH
+    FILES_CACHE_PATH = files_cache_path
+
     global PIXELATED_FONT
-    PIXELATED_FONT = ImageFont.truetype(os.path.join(PWD, 'fonts', 'PSSClone', 'PSSClone.ttf'), 10)
+    PIXELATED_FONT = ImageFont.truetype(os.path.join(PWD, "fonts", "PSSClone", "PSSClone.ttf"), 10)

--- a/src/settings.py
+++ b/src/settings.py
@@ -85,6 +85,7 @@ SETTINGS_TABLE_NAME: str = "settings"
 SETTINGS_TYPES: List[str] = ["boolean", "float", "int", "text", "timestamputc"]
 
 SPRITE_CACHE_SUB_PATH: str = "sprite_cache"
+FILES_CACHE_SUB_PATH: str = "files_cache"
 
 
 THROW_COMMAND_ERRORS: int = int(os.environ.get("THROW_COMMAND_ERRORS", "0"))


### PR DESCRIPTION
Sprites now don't get retrieved through `FileService/DownloadSprite` anymore, as it's become unreliable. Now the SpriteId gets looked up in `FileService/ListSprites` and the corresponding File downloaded and cached. Then from that file the Sprite gets extracted and cached as well.